### PR TITLE
configure image to use bash via /bin/sh (instead of dash)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN set -ex && \
     apt-get install -y \
         libpng-dev \
         && \
+    echo "dash dash/sh boolean false" | debconf-set-selections && \
+    dpkg-reconfigure dash -f noninteractive && \
     apt-get clean
 
 USER jenkins


### PR DESCRIPTION
Thanks to [mgalgs at Super User](https://superuser.com/a/1064247).

This should let us more reliably run the nvm setup script (among other things) from Jenkins.